### PR TITLE
feat: add MQTT broker and Home Assistant Docker setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+MOSQUITTO_USER = extinctcoder
+MOSQUITTO_PASSWD = Mosquitto123456#

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.DS_Store
+
 .obsidian
+docker/home_assistant/**

--- a/codebook.toml
+++ b/codebook.toml
@@ -1,0 +1,5 @@
+words = [
+    "mosquitto",
+    "MQTT",
+    "extinctcoder"
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  home_assistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+
+    container_name: home_assistant
+    hostname: home_assistant
+
+    restart: unless-stopped
+
+    ports:
+      - 8123:8123
+
+    volumes:
+      - ./docker/home_assistant/config:/config
+      - /etc/localtime:/etc/localtime:ro
+
+    environment:
+      - TZ=Asia/Dhaka
+
+  mosquitto:
+    image: eclipse-mosquitto:latest
+
+    container_name: mosquitto
+    hostname: mosquitto
+
+    restart: unless-stopped
+
+    ports:
+      - 1883:1883
+      - 9001:9001
+
+    volumes:
+      - ./docker/mosquitto/config:/mosquitto/config
+      - /etc/localtime:/etc/localtime:ro
+
+    environment:
+      - TZ=Asia/Dhaka

--- a/docker/mosquitto/config/mosquitto.conf
+++ b/docker/mosquitto/config/mosquitto.conf
@@ -1,0 +1,13 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log
+
+allow_anonymous false
+password_file /mosquitto/config/password.txt
+
+# MQTT over TCP
+listener 1883
+
+# MQTT over WebSocket
+listener 9001
+protocol websockets

--- a/docker/mosquitto/config/password.txt
+++ b/docker/mosquitto/config/password.txt
@@ -1,0 +1,1 @@
+extinctcoder:$7$101$Qfk31rFVvWpfk795$3aQPK2Uj+FvwcfBPGK+FdhHU8GmtVky0PAq9MefZDMqj9GUCT+pvcek31zhl5t0LpXn+GaHjK7NRDgXlIW1WkQ==

--- a/helpers.sh
+++ b/helpers.sh
@@ -1,0 +1,4 @@
+# Create a password file for the MQTT broker user 'extinctcoder'
+# This runs mosquitto_passwd in a Docker container to generate an encrypted password
+# The password file will be created at docker/mosquitto/config/password.txt
+docker run -it --rm -v "$PWD/docker/mosquitto/config:/mosquitto/config" eclipse-mosquitto mosquitto_passwd -c /mosquitto/config/password.txt extinctcoder


### PR DESCRIPTION
- Configure Mosquitto MQTT broker with persistence and secured access  
- Support both TCP and WebSocket protocols for MQTT  
- Add password file and helper script to manage MQTT user credentials  
- Introduce docker-compose setup for Mosquitto and Home Assistant containers  
- Set appropriate volume mounts, ports, and timezone settings in docker-compose  
- Update .gitignore to exclude local and Docker config files