### PR TITLE
chore(release): add semantic-release config and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Automated version release Schedule
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+# on:
+#   pull_request:
+#     types:
+#       - closed
+
+jobs:
+  ScheduledRelease:
+    # if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout code repository
+        id: code_checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Releasing new version with Python semantic release
+        id: release_version
+        uses: python-semantic-release/python-semantic-release@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.poetry]
+version = "0.10.1"
+name = "smart_grid"
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:tool.poetry.version:nf"]


### PR DESCRIPTION
Add pyproject.toml entries for Poetry package metadata and configure
python-semantic-release to read the version from pyproject.toml.
Introduce a GitHub Actions workflow (release.yml) to automate version
releases on pushes to main and manual dispatch. The workflow checks out
the repository with full history and runs python-semantic-release with
the repository token.

These changes enable automated, consistent version management and
releases using semantic-release and Poetry.