### PR TITLE
feat(config): clean up defaults, add logging, docker artifacts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,11 +1,20 @@
-MOSQUITTO_USER = extinctcoder
-MOSQUITTO_PASSWD = Mosquitto123456#
+############################################################################
+# Power Station Simulator Configuration
+#
+# This file contains configuration parameters for the power station simulator.
+# It defines MQTT connection settings, station identification, location, and
+# publishing intervals for simulation data.
+############################################################################
 
-PS_001_POWER_STATION_ID=PS_001
-PS_002_POWER_STATION_ID=PS_002
+PS_001_MQTT_PORT=1883
+PS_001_MQTT_HOST="mosquitto"
+PS_001_MQTT_USERNAME="extinctcoder"
+PS_001_MQTT_PASSWORD="Mosquitto123456#"
+PS_001_MQTT_TOPIC_PREFIX="smartgrid/powerstation"
 
-PS_001_LOCATION="Dhaka, Bangladesh"
-PS_002_LOCATION="Chittagong, Bangladesh"
+PS_001_ENABLE_WEBSOCKET=False
 
+PS_001_CAPACITY_KW=2600
+PS_001_POWER_STATION_ID="PS_001"
 PS_001_PUBLISH_INTERVAL_SECONDS=1
-PS_002_PUBLISH_INTERVAL_SECONDS=4
+PS_001_LOCATION="Saidpur, Bangladesh"

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docker/home_assistant/**
 # python git ignores
 venv
 
+.env
 
 **.pyc
 __pycache__

--- a/codebook.toml
+++ b/codebook.toml
@@ -18,5 +18,7 @@ words = [
     "behaviour",
     "sexualized",
     "sublicense",
-    "NONINFRINGEMENT"
+    "NONINFRINGEMENT",
+    "healthcheck",
+    "Saidpur"
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,35 @@ services:
 
     environment:
       - TZ=Asia/Dhaka
+
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "1883"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+
+  powerstation_simulator:
+    image: ps_sim:dev
+    build:
+      context: .
+      dockerfile: ps_sim.dockerfile
+
+    container_name: powerstation_simulator
+    hostname: powerstation_simulator
+
+    restart: unless-stopped
+
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+
+    env_file:
+      - .env.sample
+
+    environment:
+      - TZ=Asia/Dhaka
+      - STATION_PREFIX=PS_001
+
+    volumes:
+      - ./src/powerstation_simulator:/app/src

--- a/ps_sim.dockerfile
+++ b/ps_sim.dockerfile
@@ -1,0 +1,17 @@
+# Use minimal Python 3.13 base image (Alpine = very small footprint)
+FROM python:3.13-alpine
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy requirements file from host and rename it to requirements.txt
+COPY requirements.ps_sim.txt requirements.txt
+
+# Install Python dependencies without caching to keep image small
+RUN pip install --no-cache-dir --root-user-action=ignore -r requirements.txt
+
+# Copy application source code into the container
+COPY src/powerstation_simulator/ src/
+
+# Default command: run the main Python entrypoint
+CMD ["sh", "-c", "python src/main.py"]

--- a/requirements.ps_sim.txt
+++ b/requirements.ps_sim.txt
@@ -1,4 +1,3 @@
-jsonb
 pydantic
 paho-mqtt
 pydantic-settings

--- a/src/powerstation_simulator/config.py
+++ b/src/powerstation_simulator/config.py
@@ -1,8 +1,11 @@
 from os import getenv
 from typing import Annotated
 
+from logger import getLogger
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = getLogger(__name__)
 
 
 class AppConfig(BaseSettings):
@@ -25,25 +28,21 @@ class AppConfig(BaseSettings):
     )
 
     # Metadata (static info)
-    POWER_STATION_ID: Annotated[str, Field(alias="POWER_STATION_ID")] = "ps-001"
-    LOCATION: Annotated[str, Field(alias="LOCATION")] = "Dhaka, Bangladesh"
-    CAPACITY_KW: Annotated[int, Field(alias="CAPACITY_KW")] = 1000
+    POWER_STATION_ID: Annotated[str, Field()] = "PS_001"
+    LOCATION: Annotated[str, Field()] = "Dhaka, Bangladesh"
+    CAPACITY_KW: Annotated[int, Field()] = 1000
 
     # MQTT broker config
-    MQTT_HOST: Annotated[str, Field(alias="MQTT_HOST")] = "localhost"
-    MQTT_PORT: Annotated[int, Field(alias="MQTT_PORT")] = 1883
-    MQTT_USERNAME: Annotated[str, Field(alias="MQTT_USERNAME")] = "extinctcoder"
-    MQTT_PASSWORD: Annotated[str, Field(alias="MQTT_PASSWORD")] = "Mosquitto123456#"
-    MQTT_TOPIC_PREFIX: Annotated[str, Field(alias="MQTT_TOPIC_PREFIX")] = (
-        "smartgrid/powerstation"
-    )
+    MQTT_HOST: Annotated[str, Field()] = "127.0.0.1"
+    MQTT_PORT: Annotated[int, Field()] = 1883
+    MQTT_USERNAME: Annotated[str, Field()] = "extinctcoder"
+    MQTT_PASSWORD: Annotated[str, Field()] = "Mosquitto123456#"
+    MQTT_TOPIC_PREFIX: Annotated[str, Field()] = "smartgrid/powerstation"
 
-    ENABLE_WEBSOCKET: Annotated[bool, Field(alias="ENABLE_WEBSOCKET")] = False
+    ENABLE_WEBSOCKET: Annotated[bool, Field()] = False
 
     # Simulator settings
-    PUBLISH_INTERVAL_SECONDS: Annotated[
-        int, Field(alias="PUBLISH_INTERVAL_SECONDS")
-    ] = 2
+    PUBLISH_INTERVAL_SECONDS: Annotated[int, Field()] = 1
 
     STATUS_PUBLISH_INTERVAL_SECONDS: int = PUBLISH_INTERVAL_SECONDS * 2
     METADATA_PUBLISH_INTERVAL_SECONDS: int = PUBLISH_INTERVAL_SECONDS * 5
@@ -55,6 +54,8 @@ def load_power_station_configs(station_prefix: str | None = None) -> AppConfig:
     If no prefix is provided explicitly, reads from the STATION_PREFIX env var.
     """
     station_prefix = station_prefix or getenv("STATION_PREFIX")
+
+    logger.info(f"Simple Power Station SIMULATOR serving station : {station_prefix}")
 
     if not station_prefix:
         return AppConfig()  # fallback to default or global settings

--- a/src/powerstation_simulator/main.py
+++ b/src/powerstation_simulator/main.py
@@ -63,9 +63,7 @@ Examples:
     args = parser.parse_args()
 
     print(ps_banner)
-    logger.info(
-        f"Simple Power Station SIMULATOR serving station : {args.station_prefix}"
-    )
+
     app_config: AppConfig = load_power_station_configs(
         station_prefix=args.station_prefix
     )

--- a/src/powerstation_simulator/mqtt_client.py
+++ b/src/powerstation_simulator/mqtt_client.py
@@ -1,4 +1,6 @@
 from json import dumps
+from random import choices
+from string import ascii_letters, digits
 from typing import Any
 
 from config import AppConfig
@@ -41,7 +43,7 @@ class MQTTClient:
         self.connected: bool = False
 
         self.client: mqtt_client.Client = mqtt_client.Client(
-            client_id=client_id,
+            client_id=f"{client_id}_".join(choices(ascii_letters + digits, k=6)),
             transport="websockets" if enable_websocket else "tcp",
         )
         if username and password:


### PR DESCRIPTION
- Add lightweight Dockerfile for ps_sim using python:3.13-alpine
  to produce a minimal image and install dependencies from
  requirements.ps_sim.txt.
- Add partial docker-compose service enhancements: healthcheck for
  broker and skeleton entry for powerstation_simulator service.
- Replace Pydantic Field aliases with direct Field() usage and update
  several default values (POWER_STATION_ID -> "PS_001",
  MQTT_HOST -> "127.0.0.1", PUBLISH_INTERVAL_SECONDS -> 1,
  MQTT_TOPIC_PREFIX -> "smartgrid/powerstation"). This simplifies
  env handling and avoids redundant aliasing.
- Add logger and emit startup info in get_app_config when resolving
  station prefix to aid debugging and visibility.
- Change MQTT client id generation to a randomized suffix using
  choices(ascii_letters + digits, k=6) to avoid client id collisions
  when multiple simulators connect; keep transport selection logic.
- Expand .env.sample with clearer documentation and standardized
  PS_001_* variables (host, port, credentials, topic, websocket,
  capacity, location) to reflect updated defaults and make local
  configuration easier to follow.

Why:
- Improve observability (logger) and reduce config alias complexity.
- Prevent MQTT client-id collisions in concurrent runs.
- Provide containerization artifacts for easy local deployment and
  basic service healthchecks.
- Make sample environment file clearer and aligned with current
  defaults.